### PR TITLE
Fix markdown file path references

### DIFF
--- a/how-we-work/README.md
+++ b/how-we-work/README.md
@@ -2,13 +2,13 @@
 
 How we work is a reflection of who we are and what we believe in.
 
-We work [in teams](./teaming/staffing-teams), shaped like a [tear-drop](./teaming/teardrop).
+We work [in teams](./teaming/staffing-teams.md), shaped like a [tear-drop](./teaming/teardrop.md).
 
-We work [on-site with our clients](./working-with-clients/on-site), as well as through our high calibre [near-shore](./working-with-clients/near-shore) and [off-shore](./working-with-clients/off-shore) delivery centres.
+We work [on-site with our clients](./working-with-clients/on-site.md), as well as through our high calibre [near-shore](./working-with-clients/near-shore.md) and [off-shore](./working-with-clients/off-shore.md) delivery centres.
 
-We believe in [Agile](./methods/agile), [Kanban](./methods/kanban), and [DevOps](./methods/devops).
+We believe in [Agile](./methods/agile.md), [Kanban](./methods/kanban.md), and [DevOps](./methods/devops.md).
 
-We employ leading practices like [continuous integration](./practices/ci), [continuous delivery](./practices/cd), [test-driven development](./practices/tdd), [behaviour-driven development](./practices/bdd), and [robust quality assurance](./practices/qa).
+We employ leading practices like [continuous integration](./practices/ci.md), [continuous delivery](./practices/cd.md), [test-driven development](./practices/tdd.md), [behaviour-driven development](./practices/bdd.md), and [robust quality assurance](./practices/qa.md).
 
-We engage with clients on a [fixed price](./engagement-models/fixed-price), [time and materials](./engagement-models/time-and-materials), or [shared value](./engagement-models/shared-value) basis, depending on what is most appropriate.
+We engage with clients on a [fixed price](./engagement-models/fixed-price.md), [time and materials](./engagement-models/time-and-materials.md), or [shared value](./engagement-models/shared-value.md) basis, depending on what is most appropriate.
 

--- a/what-we-do/README.md
+++ b/what-we-do/README.md
@@ -4,25 +4,25 @@ We build great digital experiences. It's as simple and as advanced as that.
 
 Our services include:
 
-* [Digital product development](./services/digital-products)
-* [Digital platform delivery](./services/digital-platforms)
-* [Integration](./services/integration)
+* [Digital product development](./services/digital-products.md)
+* [Digital platform delivery](./services/digital-platforms.md)
+* [Integration](./services/integration.md)
 
 We do this using a range of technologies, such as:
 
-* [Front end web](./technologies/web)
-* [iOS](./technologies/iOS)
-* [Android](./technologies/android)
-* [Java and the JVM](./technologies/jvm)
-* [.Net](./technologies/dot-net)
-* [Salesforce and Force.com](./technologies/salesforce)
-* [hybris e-commerce](./technologies/hybris)
-* [Adobe's experience platform](./technologies/adobe)
+* [Front end web](./technologies/web.md)
+* [iOS](./technologies/iOS.md)
+* [Android](./technologies/android.md)
+* [Java and the JVM](./technologies/jvm.md)
+* [.Net](./technologies/dot-net.md)
+* [Salesforce and Force.com](./technologies/salesforce.md)
+* [hybris e-commerce](./technologies/hybris.md)
+* [Adobe's experience platform](./technologies/adobe.md)
 
 And then there are some things where we prefer to work with our colleagues and partners, rather than do them ourselves, such as:
 
-* [Resource augmentation](./rarely/single-roles)
-* [Technical assurance](./rarely/assurance)
-* [Engineering advisory](./rarely/advisory)
-* [Package implementation](./rarely/package-implementation)
-* [Maintenance of things we didn't build](./rarely/maintenance)
+* [Resource augmentation](./rarely/single-roles.md)
+* [Technical assurance](./rarely/assurance.md)
+* [Engineering advisory](./rarely/advisory.md)
+* [Package implementation](./rarely/package-implementation.md)
+* [Maintenance of things we didn't build](./rarely/maintenance.md)

--- a/who-we-are/README.md
+++ b/who-we-are/README.md
@@ -6,10 +6,10 @@ We work with strategists, designers and analysts to build elegant digital produc
 
 Here you can read more about:
 
-* [Who trives here](./who)
-* [Our values](./values)
-* [Our work environment](./environment)
-* [Our community](./community)
-* [Innovation and learning](./innovation)
-* [How we manage career progression](./career)
+* [Who thrives here](./who.md)
+* [Our values](./values.md)
+* [Our work environment](./environment.md)
+* [Our community](./community.md)
+* [Innovation and learning](./innovation.md)
+* [How we manage career progression](./career.md)
 


### PR DESCRIPTION
I noticed I couldn't navigate through the pages on GitHub with the current paths to markdown. 

If these are intentionally not ending in `.md` then do ignore.